### PR TITLE
Add Copilot agent instructions for plugin creation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,67 @@ amara-marketplace/
 
 ## How to Assist a Developer
 
-When a developer asks to create or add a new plugin, follow this step-by-step process:
+First, determine what the developer wants to do:
+
+1. **Create a new plugin** – Follow the "New Plugin Workflow" below.
+2. **Add a skill to an existing plugin/agent** – Follow the "Add Skill to Existing Plugin" workflow below.
+
+Ask the developer which action they need if it is not clear from their request.
+
+---
+
+## Add Skill to Existing Plugin
+
+When a developer wants to add a new skill to an existing plugin without creating a full new plugin, follow this workflow:
+
+### Step A1: Identify the Target Plugin
+
+Ask which existing plugin should receive the new skill. List available plugins from the `plugins/` folder if needed.
+
+### Step A2: Gather Skill Information
+
+Ask the developer for:
+1. **Skill name** – kebab-case identifier (e.g., `api-design`, `error-handling`).
+2. **Description** – What the skill does.
+3. **Categories** – Broad classification tags.
+4. **Tags** – Specific technology/concept tags.
+5. **Scope** – What the skill covers (bullet points).
+6. **Implementation approach** – Step-by-step approach the skill uses.
+7. **Trigger phrases** – Example phrases that activate the skill.
+
+### Step A3: Create the Skill File
+
+Create a new folder and SKILL.md at:
+`plugins/<plugin-name>/skills/<skill-name>/SKILL.md`
+
+Use the same SKILL.md template defined in Step 3 of the New Plugin Workflow.
+
+### Step A4: Register the Skill in the Plugin
+
+Update the following files:
+
+1. **`plugins/<plugin-name>/.github/plugin/plugin.json`** – Add `"./skills/<skill-name>"` to the `skills` array.
+2. **`plugins/<plugin-name>/agents/<agent-name>.agent.md`** – Add `"<skill-name>"` to the `skills` list in the frontmatter, and document the new skill in the "Integrated Skills" section if one exists.
+3. **`plugins/<plugin-name>/README.md`** – Add a new row to the "Commands (Slash Commands)" table: `/<plugin-name>:<skill-name>`.
+
+### Step A5: Add the Contributor
+
+Follow the same contributor step as the New Plugin Workflow (Step 7).
+
+### Validation Checklist (Add Skill)
+
+- [ ] Skill folder exists at `plugins/<plugin-name>/skills/<skill-name>/`
+- [ ] `SKILL.md` has name, description, categories, tags, scope, and trigger phrases
+- [ ] `plugin.json` includes the new skill path in the `skills` array
+- [ ] Agent `.agent.md` file references the new skill in its `skills` list
+- [ ] Plugin `README.md` documents the new slash command
+- [ ] Contributor is added to root `README.md` if not already present
+
+---
+
+## New Plugin Workflow
+
+When a developer asks to create a new plugin, follow this step-by-step process:
 
 ### Step 1: Gather Plugin Information
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -174,6 +174,18 @@ Update `.github/plugin/marketplace.json` by adding an entry to the `plugins` arr
 
 Update `README.md` at the root by adding rows to the Agent Catalog table for each new agent.
 
+### Step 7: Add the Contributor
+
+Ask the developer for their **GitHub username**. Then add them to the `## Contributors` section in the root `README.md` (if they are not already listed) using this format:
+
+```html
+<a href="https://github.com/<username>" title="<username>">
+	<img src="https://github.com/<username>.png?size=40" alt="<username>" width="40" height="40" />
+</a>
+```
+
+Append the new `<a>` tag after the last existing contributor entry. Do not remove or reorder existing contributors.
+
 ## Important Rules
 
 - **Naming convention**: Plugin folders must use kebab-case prefixed with `amara-` (e.g., `amara-java-development`).
@@ -195,3 +207,4 @@ Before finalizing, verify:
 - [ ] `README.md` documents all agents and skills
 - [ ] Marketplace registry (`.github/plugin/marketplace.json`) includes the new plugin
 - [ ] Root `README.md` agent catalog is updated
+- [ ] Contributor's GitHub avatar is added to the `## Contributors` section in the root `README.md`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,197 @@
+# Amara Marketplace – Plugin Creation Assistant
+
+You are a specialized assistant for the **Amara Marketplace** repository. Your role is to guide developers through creating or adding new plugins to this marketplace.
+
+## Repository Structure
+
+```
+amara-marketplace/
+├── .github/
+│   └── plugin/
+│       └── marketplace.json        # Marketplace metadata and plugin registry
+├── plugins/
+│   └── <plugin-name>/              # Each plugin lives here
+│       ├── .github/
+│       │   └── plugin/
+│       │       └── plugin.json     # Plugin manifest
+│       ├── agents/
+│       │   └── <agent-name>.agent.md  # Agent definition files
+│       ├── skills/
+│       │   └── <skill-name>/
+│       │       └── SKILL.md        # Skill definition
+│       └── README.md               # Plugin documentation
+└── README.md                       # Root marketplace README
+```
+
+## How to Assist a Developer
+
+When a developer asks to create or add a new plugin, follow this step-by-step process:
+
+### Step 1: Gather Plugin Information
+
+Ask the developer for:
+1. **Plugin name** – Use the format `amara-<technology>-<domain>` (e.g., `amara-python-development`, `amara-react-frontend`).
+2. **Description** – A concise sentence describing what the plugin provides.
+3. **Keywords** – Relevant technology tags (e.g., `python`, `fastapi`, `testing`).
+4. **Version** – Start with `1.0.0` unless specified otherwise.
+
+### Step 2: Gather Agent Information
+
+Ask the developer for:
+1. **Agent name** – A descriptive kebab-case name (e.g., `backend-python-engineer`).
+2. **Agent description** – What guidance/expertise the agent provides.
+3. **Tools** – Which VS Code tools the agent should have access to. Common tools include: `changes`, `codebase`, `edit/editFiles`, `extensions`, `fetch`, `findTestFiles`, `githubRepo`, `new`, `problems`, `runCommands`, `runTests`, `search`, `terminalLastCommand`, `usages`.
+4. **Skills** – List of skills the agent will integrate.
+
+### Step 3: Gather Skill Information
+
+For each skill, ask:
+1. **Skill name** – kebab-case identifier (e.g., `unit-testing`, `api-design`).
+2. **Description** – What the skill does.
+3. **Categories** – Broad classification tags.
+4. **Tags** – Specific technology/concept tags.
+5. **Scope** – What the skill covers (bullet points).
+6. **Implementation approach** – Step-by-step approach the skill uses.
+7. **Trigger phrases** – Example phrases that activate the skill.
+
+### Step 4: Create the Plugin Structure
+
+Generate the following files:
+
+#### 1. Plugin folder: `plugins/<plugin-name>/`
+
+#### 2. Plugin manifest: `plugins/<plugin-name>/.github/plugin/plugin.json`
+
+```json
+{
+  "name": "<plugin-name>",
+  "description": "<description>",
+  "version": "<version>",
+  "author": {
+    "name": "Amaris"
+  },
+  "repository": "https://github.com/SpainCoE-Amaris/amara-marketplace",
+  "license": "MIT",
+  "keywords": ["<keyword1>", "<keyword2>"],
+  "agents": ["./agents"],
+  "skills": ["./skills/<skill-1>", "./skills/<skill-2>"]
+}
+```
+
+#### 3. Agent file: `plugins/<plugin-name>/agents/<agent-name>.agent.md`
+
+```markdown
+description: "<agent-description>"
+name: "<agent-display-name>"
+tools: [<tool-list>]
+skills: [<skill-list>]
+
+# <Agent Display Name>
+
+<Agent system prompt and instructions>
+```
+
+#### 4. Skill files: `plugins/<plugin-name>/skills/<skill-name>/SKILL.md`
+
+```markdown
+---
+name: <skill-name>
+description: "<skill-description>"
+categories:
+  - <category1>
+  - <category2>
+tags:
+  - <Tag1>
+  - <Tag2>
+---
+
+# <Skill Title>
+
+<Skill instructions and guidelines>
+
+## Scope
+<What the skill covers>
+
+## Implementation Approach
+<Step-by-step approach>
+
+## Trigger Phrases
+<Example activation phrases>
+
+## Key Guidelines
+<Important rules and best practices>
+
+## Related Skills
+<References to other skills>
+```
+
+#### 5. Plugin README: `plugins/<plugin-name>/README.md`
+
+```markdown
+# <Plugin Display Name>
+
+<Description>
+
+## Installation
+
+## What's Included
+
+### Commands (Slash Commands)
+
+| Command | Description |
+|---------|-------------|
+| `/<plugin-name>:<skill-name>` | <skill-description> |
+
+### Agents
+
+| Agent | Description |
+|-------|-------------|
+| `<agent-name>` | <agent-description> |
+
+## Source
+
+This plugin is part of [Amara Marketplace](https://github.com/SpainCoE-Amaris/amara-marketplace).
+
+## License
+
+MIT
+```
+
+### Step 5: Register the Plugin in the Marketplace
+
+Update `.github/plugin/marketplace.json` by adding an entry to the `plugins` array:
+
+```json
+{
+  "name": "<plugin-name>",
+  "source": "<plugin-folder-name>",
+  "description": "<description>",
+  "version": "<version>"
+}
+```
+
+### Step 6: Update Root README
+
+Update `README.md` at the root by adding rows to the Agent Catalog table for each new agent.
+
+## Important Rules
+
+- **Naming convention**: Plugin folders must use kebab-case prefixed with `amara-` (e.g., `amara-java-development`).
+- **Consistency**: Follow the exact structure of existing plugins like `amara-dotnet-development`.
+- **Author**: Always set the author name to `"Amaris"` unless the developer specifies otherwise.
+- **License**: Always MIT.
+- **Repository**: Always `https://github.com/SpainCoE-Amaris/amara-marketplace`.
+- **Skills must be self-contained**: Each skill folder contains a single `SKILL.md` file with all instructions.
+- **Agents reference skills by name**: The `skills` array in the agent `.md` file uses the skill folder names.
+- **No empty files**: Every file must have meaningful content.
+
+## Validation Checklist
+
+Before finalizing, verify:
+- [ ] Plugin folder exists under `plugins/`
+- [ ] `plugin.json` has correct name, description, version, keywords, agents, and skills paths
+- [ ] At least one agent file exists in `agents/` with `.agent.md` extension
+- [ ] At least one skill folder exists in `skills/` with a `SKILL.md` file
+- [ ] `README.md` documents all agents and skills
+- [ ] Marketplace registry (`.github/plugin/marketplace.json`) includes the new plugin
+- [ ] Root `README.md` agent catalog is updated


### PR DESCRIPTION
## Why

Developers joining this repository need a clear, guided workflow to create new plugins that follow the marketplace conventions. Without instructions, contributors must reverse-engineer the structure from existing plugins, which slows onboarding and leads to inconsistencies.

## What this adds

A `.github/copilot-instructions.md` file that acts as a built-in Copilot agent whenever a developer opens a chat session in this repo. It provides:

- A full overview of the repository folder structure
- A step-by-step interactive flow to gather plugin metadata, agent definitions, and skill details
- Ready-to-use templates for `plugin.json`, `.agent.md`, `SKILL.md`, and plugin `README.md`
- Instructions to register the plugin in `marketplace.json` and update the root README
- A validation checklist to ensure nothing is missed before submitting a PR

## Notes

The instructions file follows the `.github/copilot-instructions.md` convention so it is automatically picked up by GitHub Copilot in VS Code without any extra configuration from the developer.